### PR TITLE
Clarifies messages so players know it's their turn

### DIFF
--- a/lib/game_play.rb
+++ b/lib/game_play.rb
@@ -4,7 +4,6 @@ class GamePlay
     
     PLAYER_MARKS = ["X", "O"].freeze
 
-    # TODO: Is this the correct place for the UI and Mes?
     def initialize(ui, messages, player_marks=nil)
         @ui = ui
         @messages = messages

--- a/lib/game_play.rb
+++ b/lib/game_play.rb
@@ -25,16 +25,16 @@ class GamePlay
          board[spot - 1] = player_mark
     end
 
-    def select_spot(board)
-        @ui.display_message(@messages.lookup(:get_spot))
-        spot = @ui.get_spot_input
-        is_valid = @validate.valid_free_spot?(spot, board)
-        if !is_valid
-            @ui.display_message(@messages.lookup(:invalid_input)) 
-            return select_spot(board)
-        else
-            return spot
-        end
+    def select_spot(board, player_mark)
+      @ui.display_message(@messages.lookup(:"#{player_mark}_get_spot"))
+      spot = @ui.get_spot_input
+      is_valid = @validate.valid_free_spot?(spot, board)
+      if !is_valid
+          @ui.display_message(@messages.lookup(:invalid_input)) 
+          return select_spot(board, player_mark)
+      else
+          return spot
+      end
     end
 
     def check_for_win_draw(board)

--- a/lib/messages.rb
+++ b/lib/messages.rb
@@ -2,8 +2,9 @@ class Message
 
     TTT_MESSAGES = {
       welcome: "Welcome to Tic Tac Toe!\n\n",
-      instructions: "Tic Tac Toe is a two player game played\non a 3 x 3 grid. When prompted, each\nplayer will place their mark by entering\na number between 1-9 that corresponds with\nan available square on the grid.",
-      get_spot: "Please select an available spot between 1-9:\n",
+      instructions: "Tic Tac Toe is a two player game played\non a 3 x 3 grid. When prompted, each\nplayer will place their mark by entering\na number between 1-9 that corresponds with\nan available square on the grid.\n\nPlayer X goes first.\n",
+      X_get_spot: "Player X, enter an available spot between 1-9:\n",
+      O_get_spot: "Player O, enter an available spot between 1-9:\n",
       invalid_input: "That's not a valid spot.\n",
       X_win: "Congratulations player X, you have won!\n",
       O_win: "Congratulations player O, you have won!\n",

--- a/lib/tic_tac_toe.rb
+++ b/lib/tic_tac_toe.rb
@@ -19,7 +19,7 @@ class TicTacToe
     @ui.display_message(@message.lookup(:welcome))
     @ui.display_message(@message.lookup(:instructions))
     @ui.display_board(@board)
-    while !@game_end do
+    until @game_end do
       take_turns
     end
     display_game_over_messages

--- a/lib/tic_tac_toe.rb
+++ b/lib/tic_tac_toe.rb
@@ -28,7 +28,7 @@ class TicTacToe
   private 
   
   def take_turns
-    spot = @game.select_spot(@board)
+    spot = @game.select_spot(@board, @current_player)
     @game.mark_board(@board, @current_player, spot)
     @ui.display_board(@board)
     @game_end = @game.check_for_win_draw(@board) 

--- a/spec/game_play_spec.rb
+++ b/spec/game_play_spec.rb
@@ -22,8 +22,8 @@ describe GamePlay do
     board = [1, 2, 3, 4, 5, 6, 7, 8, 9]
     @game_play.mark_board(board, 'X', 5)
     @game_play.mark_board(board, 'O', 1)
-    result = ['O', 2, 3, 4, 'X', 6, 7, 8, 9]
-    expect(board).to eq result
+
+    expect(board).to eq(@board)
   end
 
   context "get_spot" do

--- a/spec/game_play_spec.rb
+++ b/spec/game_play_spec.rb
@@ -31,12 +31,12 @@ describe GamePlay do
 
     it 'select spot returns a valid player input as spot' do
         allow(@ui).to receive(:get_spot_input).and_return(9)
-        expect(@game_play.select_spot(@board)).to eq(9)
+        expect(@game_play.select_spot(@board, 'X')).to eq(9)
     end  
 
     it 'reprompt the player if their input is invalid' do
         allow(@ui).to receive(:get_spot_input).and_return(5, 9)
-        expect(@game_play.select_spot(@board)).to eq(9)
+        expect(@game_play.select_spot(@board, 'X')).to eq(9)
     end
   end
 


### PR DESCRIPTION
Adds:
- Two new player specific messages to the `TTT_MESSAGES` hash table
- select_spot in GamePlay now uses the current player_mark to look up player specific `get_spot` message
- changes to tests to account for new `player_mark` argument
 
I had more ideas--such as asking for player name input and creating a new player class to house player specific functionality--but wanted to first open a PR that fulfills the scope of the "Establish who's playing" ticket expectations before building anything else.